### PR TITLE
Update Python version to 3.13.7 in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,7 +10,7 @@ services:
     healthCheckPath: /health
     envVars:
       - key: PYTHON_VERSION
-        value: 3.11.0
+        value: 3.13.7
       - key: PORT
         generateValue: true
       - key: OPENAI_API_KEY


### PR DESCRIPTION
Bumped the PYTHON_VERSION environment variable from 3.11.0 to 3.13.7 to use a newer Python release for the service.