### PR TITLE
Remove PYTHON_VERSION env var from render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -9,8 +9,6 @@ services:
     branch: main
     healthCheckPath: /health
     envVars:
-      - key: PYTHON_VERSION
-        value: 3.11.0
       - key: PORT
         generateValue: true
       - key: OPENAI_API_KEY


### PR DESCRIPTION
The PYTHON_VERSION environment variable is no longer set in the service configuration. This may be due to using a default Python version or managing the version elsewhere.